### PR TITLE
Feature/#2 갤러리 페이지 업데이트, 삭제 / 갤러리 폴더 생성하여 업로드, 읽기, 업데이트

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -64,7 +64,7 @@ const Header = () => {
           <HeaderItem>
             <IconImg src={gelleryBlack} alt="gellery icon" />
             <Span>
-              <Link to="/gallery">gellery</Link>
+              <Link to="/gallery">gallery</Link>
             </Span>
           </HeaderItem>
           <HeaderItem>

--- a/src/components/commute/CommuteButtonComponent.tsx
+++ b/src/components/commute/CommuteButtonComponent.tsx
@@ -50,14 +50,14 @@ const CommuteButtonComponent = () => {
     }
   };
 
-  useEffect(() => {
-    const timer = setInterval(() => {
-      checkOnOff();
-    }, 1000);
-    return () => {
-      clearInterval(timer);
-    };
-  }, []);
+  // useEffect(() => {
+  //   const timer = setInterval(() => {
+  //     checkOnOff();
+  //   }, 1000);
+  //   return () => {
+  //     clearInterval(timer);
+  //   };
+  // }, []);
 
   return (
     <>

--- a/src/components/commute/CommuteModal.tsx
+++ b/src/components/commute/CommuteModal.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import "./CommuteModal.css";
 import { doc, deleteDoc, setDoc } from "firebase/firestore";
 import { db } from "../../firebase";
 import {

--- a/src/components/gallery/GalleryDetailModal.tsx
+++ b/src/components/gallery/GalleryDetailModal.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import styled from "styled-components";
-import { deleteObject, ref } from "firebase/storage";
+import { deleteObject, ref, uploadString } from "firebase/storage";
 import { storage } from "../../firebase";
 import closeIconUrl from "../../assets/icons/gallery_icon/image_close_icon.png";
+import uploadIconUrl from "../../assets/icons/gallery_icon/image_upload_icon.png";
 import {
   ModalBackground,
   CloseButton,
@@ -17,7 +18,7 @@ interface DetailModalProps {
 
 const ModalBox = styled.div`
   width: 950px;
-  height: 800px;
+  height: 750px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -35,38 +36,121 @@ const DetailImage = styled.img`
   margin-top: -20px;
 `;
 
-const Description = styled.p`
-  font: normal normal bold 12px/20px Noto Sans KR;
-  margin: 10px auto 5px 120px;
-  width: 700px;
-  color: #949494;
-`;
-
 const Content = styled.p`
-  font: normal normal bold 20px/32px Noto Sans KR;
-  margin: 0px auto 20px 120px;
+  font: normal normal normal 16px/32px Noto Sans KR;
+  margin: 10px auto 20px 120px;
   width: 700px;
   white-wrap: nowrap;
   border-box: box-sizing;
   overflow-y: scroll;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: lightgray;
+    border-radius: 100px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: gray;
+    border-radius: 100px;
+  }
+`;
+
+const UploadBox = styled.div`
+  width: 700px;
+  height: 460px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.02);
+  box-shadow: 0px 3px 6px #00000029;
+  border: 2px solid #d2d2d2;
+  border-radius: 30px;
+  cursor: pointer;
+`;
+
+const ImagePreview = styled.img`
+  width: 700px;
+  height: 360px;
+  object-fit: cover;
+  border-radius: 30px;
+  box-shadow: 0px 3px 6px #00000029;
+`;
+
+const ModalUploadIcon = styled.img`
+  width: 80px;
+  height: 80px;
+  text-align: center;
+`;
+
+const UploadDescription = styled.p`
+  font: normal normal bold 20px/32px Noto Sans KR;
+  margin-top: 20px;
+  > img {
+    width: 25px;
+    height: 25px;
+  }
+`;
+
+const FileNameBox = styled.div`
+  display: flex;
+  margin: 20px auto 0px 120px;
+  > svg {
+    margin-right: 3px;
+  }
+`;
+
+const Input = styled.input`
+  display: none;
+`;
+
+const FileName = styled.p`
+  margin-left: 5px;
+  text-align: center;
+  font: normal normal bold 16px/18px Noto Sans KR;
 `;
 
 const GalleryDetailModal: React.FC<DetailModalProps> = ({
   imageUrl,
   onClose,
 }) => {
+  const [isEdit, setIsEdit] = useState(false);
+  const [imageName, setImageName] = useState<any | null>(null);
+  const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
+
+  // get image name
+  const getImageName = () => {
+    const url = imageUrl;
+    const parts = url.split("/");
+    const encodedFileName = parts[parts.length - 1].split("?")[0];
+    const imageFileName = decodeURIComponent(encodedFileName);
+    setImageName(imageFileName);
+  };
+
+  useEffect(() => {
+    getImageName();
+
+    return () => {
+      setImageName(null);
+    };
+  }, []);
+
+  // image edit
+  const handleIsEdit = () => {
+    setIsEdit(!isEdit);
+  };
+
   // image delete
   const deleteImage = async () => {
     // eslint-disable-next-line no-restricted-globals
     if (confirm("이미지를 삭제하시겠습니까?")) {
       try {
-        const url = imageUrl;
-        const parts = url.split("/");
-        const encodedFileName = parts[parts.length - 1].split("?")[0];
-        const decodedFileName = decodeURIComponent(encodedFileName);
-
         // 이미지 삭제
-        const imageRef = ref(storage, decodedFileName);
+        const imageRef = ref(storage, imageName);
         await deleteObject(imageRef);
         alert("선택한 이미지가 삭제되었습니다.");
         window.location.href = "/gallery";
@@ -79,38 +163,202 @@ const GalleryDetailModal: React.FC<DetailModalProps> = ({
     }
   };
 
+  // click input
+  const handleInputFile = () => {
+    if (imageInputRef.current) {
+      imageInputRef.current.click();
+    }
+  };
+
+  // selected image preview
+  const handlePreview = (file: File | undefined) => {
+    if (file) {
+      setSelectedFileName(file?.name || null);
+
+      const reader = new FileReader();
+      reader.onload = event => {
+        if (event.target) {
+          setSelectedImage(event.target.result as string);
+        }
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  // check image file
+  const checkImageFile = (file: File | undefined): boolean => {
+    if (file) {
+      const allowedExtentions = ["png", "jpg", "jpeg", "gif"];
+      const fileExtension: string =
+        file.name.split(".").pop()?.toLowerCase() || "";
+
+      if (allowedExtentions.includes(fileExtension)) {
+        return true;
+      }
+    } else {
+      return false;
+    }
+    return false;
+  };
+
+  // drag input
+  const handleDrag = useCallback(async (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const selectedFile: File | undefined = e.dataTransfer.files[0];
+
+    if (checkImageFile(selectedFile)) {
+      setSelectedFileName(selectedFile?.name || null);
+      handlePreview(selectedFile);
+    } else {
+      alert("이미지 파일만 업로드가 가능합니다.");
+      setSelectedFileName(null);
+      setSelectedImage(null);
+    }
+  }, []);
+
+  // file change
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile: File | undefined = e.target.files?.[0];
+
+    if (checkImageFile(selectedFile)) {
+      handlePreview(selectedFile);
+    } else {
+      alert("이미지 파일만 업로드가 가능합니다.");
+    }
+  };
+
+  // image update
+  const handleImageUpdate = async () => {
+    if (!selectedImage) {
+      alert("파일을 선택해주세요.");
+    }
+    try {
+      if (selectedImage) {
+        // 이미지 삭제
+        const imageRef = ref(storage, imageName);
+        await deleteObject(imageRef);
+        // 이미지 업로드
+        const storageRef = ref(storage, `images/${selectedFileName}`);
+        await uploadString(storageRef, selectedImage, "data_url");
+        alert("이미지가 변경되었습니다.");
+        window.location.href = "/gallery";
+      }
+    } catch (error) {
+      console.error("Error : ", error);
+    }
+  };
+
   return (
     <ModalBackground onClick={onClose}>
       <ModalBox onClick={e => e.stopPropagation()}>
         <CloseButton onClick={onClose}>
           <img src={closeIconUrl} alt="close icon" />
         </CloseButton>
-        <DetailImage src={imageUrl} alt="Image Detail" />
-        <Description>Category | yyyy-mm-dd</Description>
+        {isEdit ? (
+          <UploadBox
+            onClick={handleInputFile}
+            onDrop={handleDrag}
+            onDragOver={e => e.preventDefault()}>
+            {selectedImage ? (
+              <ImagePreview src={selectedImage} alt="미리보기" />
+            ) : (
+              <>
+                <ModalUploadIcon src={uploadIconUrl} alt="upload icon" />
+                <UploadDescription>
+                  파일 업로드를 위해 클릭하거나 드래그하세요.
+                </UploadDescription>
+              </>
+            )}
+          </UploadBox>
+        ) : (
+          <DetailImage src={imageUrl} alt="Image Detail" />
+        )}
+
+        <FileNameBox>
+          {isEdit && (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="1em"
+              viewBox="0 0 448 512">
+              <path d="M364.2 83.8c-24.4-24.4-64-24.4-88.4 0l-184 184c-42.1 42.1-42.1 110.3 0 152.4s110.3 42.1 152.4 0l152-152c10.9-10.9 28.7-10.9 39.6 0s10.9 28.7 0 39.6l-152 152c-64 64-167.6 64-231.6 0s-64-167.6 0-231.6l184-184c46.3-46.3 121.3-46.3 167.6 0s46.3 121.3 0 167.6l-176 176c-28.6 28.6-75 28.6-103.6 0s-28.6-75 0-103.6l144-144c10.9-10.9 28.7-10.9 39.6 0s10.9 28.7 0 39.6l-144 144c-6.7 6.7-6.7 17.7 0 24.4s17.7 6.7 24.4 0l176-176c24.4-24.4 24.4-64 0-88.4z" />
+            </svg>
+          )}
+          <Input
+            type="file"
+            ref={imageInputRef}
+            onChange={handleFileChange}
+            accept=".png,.jpg,.jpeg,.gif"
+          />
+
+          <FileName>
+            {isEdit ? selectedFileName || "이미지.png" : imageName}
+          </FileName>
+        </FileNameBox>
+
         <Content>
-          이미지의 상세 설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세
-          설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세 설명입니다.
-          이미지의 상세한 설명입니다. 이미지의 상세 설명입니다. 이미지의 상세한
-          설명입니다. 이미지의 상세 설명입니다. 이미지의 상세한 설명입니다.
-          이미지의 상세 설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세
-          설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세 설명입니다.
-          이미지의 상세한 설명입니다. 이미지의 상세 설명입니다. 이미지의 상세한
-          설명입니다. 이미지의 상세 설명입니다. 이미지의 상세한 설명입니다.
-          이미지의 상세 설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세
-          설명입니다. 이미지의 상세한 설명입니다.
+          이미지의 상세 설명입니다.
+          <br />
+          이미지에 관련된 설명을 확인할 수 있습니다.
+          <br />
+          이미지의 상세 설명입니다.
+          <br />
+          이미지에 관련된 설명을 확인할 수 있습니다.
+          <br />
+          이미지의 상세 설명입니다.
+          <br />
+          이미지에 관련된 설명을 확인할 수 있습니다.
+          <br />
+          이미지의 상세 설명입니다.
+          <br />
+          이미지에 관련된 설명을 확인할 수 있습니다.
+          <br />
         </Content>
         <ButtonBox>
-          <Button
-            color="#000"
-            borderColor="#000"
-            backgroundColor="#fff"
-            type="button"
-            onClick={deleteImage}>
-            Delete
-          </Button>
-          <Button color="#fff" backgroundColor="#000" type="button">
-            Save
-          </Button>
+          {isEdit ? (
+            <>
+              <Button
+                onClick={() => setIsEdit(!isEdit)}
+                color="#000"
+                borderColor="#000"
+                backgroundColor="#fff"
+                type="button">
+                Cancel
+              </Button>
+              <Button
+                color="#000"
+                borderColor="#000"
+                backgroundColor="#fff"
+                type="button"
+                onClick={deleteImage}>
+                Delete
+              </Button>
+              <Button
+                onClick={handleImageUpdate}
+                color="#fff"
+                backgroundColor="#000"
+                type="button">
+                Save
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                onClick={onClose}
+                color="#000"
+                borderColor="#000"
+                backgroundColor="#fff"
+                type="button">
+                Cancel
+              </Button>
+              <Button
+                onClick={handleIsEdit}
+                color="#fff"
+                backgroundColor="#000"
+                type="button">
+                Edit
+              </Button>
+            </>
+          )}
         </ButtonBox>
       </ModalBox>
     </ModalBackground>

--- a/src/components/gallery/GalleryDetailModal.tsx
+++ b/src/components/gallery/GalleryDetailModal.tsx
@@ -1,9 +1,14 @@
 import React from "react";
 import styled from "styled-components";
+import { deleteObject, ref } from "firebase/storage";
+import { storage } from "../../firebase";
 import closeIconUrl from "../../assets/icons/gallery_icon/image_close_icon.png";
-import { ModalBackground } from "./GalleryModal";
-import { CloseButton } from "./GalleryModal";
-import { ButtonBox, Button } from "./GalleryModal";
+import {
+  ModalBackground,
+  CloseButton,
+  ButtonBox,
+  Button,
+} from "./GalleryModal";
 
 interface DetailModalProps {
   imageUrl: string;
@@ -11,7 +16,7 @@ interface DetailModalProps {
 }
 
 const ModalBox = styled.div`
-  width: 1000px;
+  width: 950px;
   height: 800px;
   margin: 0 auto;
   display: flex;
@@ -27,11 +32,19 @@ const DetailImage = styled.img`
   width: 700px;
   height: auto;
   max-height: 100%;
+  margin-top: -20px;
 `;
 
 const Description = styled.p`
+  font: normal normal bold 12px/20px Noto Sans KR;
+  margin: 10px auto 5px 120px;
+  width: 700px;
+  color: #949494;
+`;
+
+const Content = styled.p`
   font: normal normal bold 20px/32px Noto Sans KR;
-  margin: 20px auto 20px 135px;
+  margin: 0px auto 20px 120px;
   width: 700px;
   white-wrap: nowrap;
   border-box: box-sizing;
@@ -42,6 +55,30 @@ const GalleryDetailModal: React.FC<DetailModalProps> = ({
   imageUrl,
   onClose,
 }) => {
+  // image delete
+  const deleteImage = async () => {
+    // eslint-disable-next-line no-restricted-globals
+    if (confirm("이미지를 삭제하시겠습니까?")) {
+      try {
+        const url = imageUrl;
+        const parts = url.split("/");
+        const encodedFileName = parts[parts.length - 1].split("?")[0];
+        const decodedFileName = decodeURIComponent(encodedFileName);
+
+        // 이미지 삭제
+        const imageRef = ref(storage, decodedFileName);
+        await deleteObject(imageRef);
+        alert("선택한 이미지가 삭제되었습니다.");
+        window.location.href = "/gallery";
+      } catch (error: unknown | Error) {
+        const errorMessage = `이미지 삭제에 실패하였습니다. \n\nerror: ${error}`;
+        alert(errorMessage);
+      }
+    } else {
+      alert("이미지 삭제를 취소하셨습니다.");
+    }
+  };
+
   return (
     <ModalBackground onClick={onClose}>
       <ModalBox onClick={e => e.stopPropagation()}>
@@ -49,7 +86,8 @@ const GalleryDetailModal: React.FC<DetailModalProps> = ({
           <img src={closeIconUrl} alt="close icon" />
         </CloseButton>
         <DetailImage src={imageUrl} alt="Image Detail" />
-        <Description>
+        <Description>Category | yyyy-mm-dd</Description>
+        <Content>
           이미지의 상세 설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세
           설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세 설명입니다.
           이미지의 상세한 설명입니다. 이미지의 상세 설명입니다. 이미지의 상세한
@@ -60,13 +98,14 @@ const GalleryDetailModal: React.FC<DetailModalProps> = ({
           설명입니다. 이미지의 상세 설명입니다. 이미지의 상세한 설명입니다.
           이미지의 상세 설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세
           설명입니다. 이미지의 상세한 설명입니다.
-        </Description>
+        </Content>
         <ButtonBox>
           <Button
             color="#000"
             borderColor="#000"
             backgroundColor="#fff"
-            type="button">
+            type="button"
+            onClick={deleteImage}>
             Delete
           </Button>
           <Button color="#fff" backgroundColor="#000" type="button">

--- a/src/components/gallery/GalleryDetailModal.tsx
+++ b/src/components/gallery/GalleryDetailModal.tsx
@@ -7,8 +7,16 @@ import uploadIconUrl from "../../assets/icons/gallery_icon/image_upload_icon.png
 import {
   ModalBackground,
   CloseButton,
+  UploadDescription,
+  FileNameBox,
+  Input,
+  FileName,
   ButtonBox,
   Button,
+  UploadBox,
+  ImagePreview,
+  ModalBox,
+  ModalUploadIcon,
 } from "./GalleryModal";
 
 interface DetailModalProps {
@@ -16,100 +24,43 @@ interface DetailModalProps {
   onClose: () => void;
 }
 
-const ModalBox = styled.div`
+const DetailModalBox = styled(ModalBox)`
   width: 950px;
-  height: 750px;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background: #fff;
-  border-radius: 20px;
-  padding: 10px;
-  z-index: 99;
+  height: 700px;
 `;
 
 const DetailImage = styled.img`
-  width: 700px;
-  height: auto;
-  max-height: 100%;
-  margin-top: -20px;
+  width: 750px;
+  max-height: 460px;
+  object-fit: cover;
+  margin: auto 0;
 `;
 
-const Content = styled.p`
-  font: normal normal normal 16px/32px Noto Sans KR;
-  margin: 10px auto 20px 120px;
-  width: 700px;
-  white-wrap: nowrap;
-  border-box: box-sizing;
-  overflow-y: scroll;
-
-  &::-webkit-scrollbar {
-    width: 8px;
-  }
-  &::-webkit-scrollbar-track {
-    background-color: lightgray;
-    border-radius: 100px;
-  }
-  &::-webkit-scrollbar-thumb {
-    background-color: gray;
-    border-radius: 100px;
-  }
-`;
-
-const UploadBox = styled.div`
+const DetailUploadBox = styled(UploadBox)`
   width: 700px;
   height: 460px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba(0, 0, 0, 0.02);
-  box-shadow: 0px 3px 6px #00000029;
-  border: 2px solid #d2d2d2;
-  border-radius: 30px;
-  cursor: pointer;
 `;
 
-const ImagePreview = styled.img`
+const DetailImagePreview = styled(ImagePreview)`
   width: 700px;
-  height: 360px;
-  object-fit: cover;
-  border-radius: 30px;
-  box-shadow: 0px 3px 6px #00000029;
+  height: 460px;
 `;
 
-const ModalUploadIcon = styled.img`
-  width: 80px;
-  height: 80px;
-  text-align: center;
-`;
-
-const UploadDescription = styled.p`
-  font: normal normal bold 20px/32px Noto Sans KR;
-  margin-top: 20px;
-  > img {
-    width: 25px;
-    height: 25px;
-  }
-`;
-
-const FileNameBox = styled.div`
-  display: flex;
+const DetailFileNameBox = styled(FileNameBox)`
   margin: 20px auto 0px 120px;
-  > svg {
-    margin-right: 3px;
-  }
 `;
 
-const Input = styled.input`
-  display: none;
-`;
-
-const FileName = styled.p`
-  margin-left: 5px;
+const Category = styled.p`
+  margin-left: -25px;
+  margin-top: -30px;
   text-align: center;
-  font: normal normal bold 16px/18px Noto Sans KR;
+  font: normal normal bold 12px Noto Sans KR;
+  color: #808080;
+`;
+
+const EditCategory = styled.p`
+  margin-right: 5px;
+  font: normal normal bold 14px/18px Noto Sans KR;
 `;
 
 const GalleryDetailModal: React.FC<DetailModalProps> = ({
@@ -117,9 +68,13 @@ const GalleryDetailModal: React.FC<DetailModalProps> = ({
   onClose,
 }) => {
   const [isEdit, setIsEdit] = useState(false);
+
   const [imageName, setImageName] = useState<any | null>(null);
+  const [categoryName, setCategoryName] = useState<any | null>(null);
+
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
   const imageInputRef = useRef<HTMLInputElement>(null);
 
   // get image name
@@ -131,15 +86,25 @@ const GalleryDetailModal: React.FC<DetailModalProps> = ({
     setImageName(imageFileName);
   };
 
+  const getCategoryName = () => {
+    if (imageName) {
+      const parts = imageName?.split("/");
+      const category = parts[1].toUpperCase();
+      setCategoryName(category);
+    }
+  };
+
   useEffect(() => {
     getImageName();
+    getCategoryName();
 
     return () => {
       setImageName(null);
+      setCategoryName(null);
     };
-  }, []);
+  }, [imageName, categoryName]);
 
-  // image edit
+  // image handleIsedit
   const handleIsEdit = () => {
     setIsEdit(!isEdit);
   };
@@ -238,7 +203,10 @@ const GalleryDetailModal: React.FC<DetailModalProps> = ({
         const imageRef = ref(storage, imageName);
         await deleteObject(imageRef);
         // 이미지 업로드
-        const storageRef = ref(storage, `images/${selectedFileName}`);
+        const storageRef = ref(
+          storage,
+          `images/${categoryName.toLowerCase()}/${selectedFileName}`,
+        );
         await uploadString(storageRef, selectedImage, "data_url");
         alert("이미지가 변경되었습니다.");
         window.location.href = "/gallery";
@@ -250,17 +218,17 @@ const GalleryDetailModal: React.FC<DetailModalProps> = ({
 
   return (
     <ModalBackground onClick={onClose}>
-      <ModalBox onClick={e => e.stopPropagation()}>
+      <DetailModalBox onClick={e => e.stopPropagation()}>
         <CloseButton onClick={onClose}>
           <img src={closeIconUrl} alt="close icon" />
         </CloseButton>
         {isEdit ? (
-          <UploadBox
+          <DetailUploadBox
             onClick={handleInputFile}
             onDrop={handleDrag}
             onDragOver={e => e.preventDefault()}>
             {selectedImage ? (
-              <ImagePreview src={selectedImage} alt="미리보기" />
+              <DetailImagePreview src={selectedImage} alt="미리보기" />
             ) : (
               <>
                 <ModalUploadIcon src={uploadIconUrl} alt="upload icon" />
@@ -269,12 +237,13 @@ const GalleryDetailModal: React.FC<DetailModalProps> = ({
                 </UploadDescription>
               </>
             )}
-          </UploadBox>
+          </DetailUploadBox>
         ) : (
           <DetailImage src={imageUrl} alt="Image Detail" />
         )}
 
-        <FileNameBox>
+        <DetailFileNameBox>
+          {isEdit && <EditCategory>{categoryName} | </EditCategory>}
           {isEdit && (
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -290,29 +259,13 @@ const GalleryDetailModal: React.FC<DetailModalProps> = ({
             accept=".png,.jpg,.jpeg,.gif"
           />
 
-          <FileName>
-            {isEdit ? selectedFileName || "이미지.png" : imageName}
-          </FileName>
-        </FileNameBox>
+          {isEdit ? (
+            <FileName>{selectedFileName || "이미지.png"}</FileName>
+          ) : (
+            <Category>CATEGORY | {categoryName}</Category>
+          )}
+        </DetailFileNameBox>
 
-        <Content>
-          이미지의 상세 설명입니다.
-          <br />
-          이미지에 관련된 설명을 확인할 수 있습니다.
-          <br />
-          이미지의 상세 설명입니다.
-          <br />
-          이미지에 관련된 설명을 확인할 수 있습니다.
-          <br />
-          이미지의 상세 설명입니다.
-          <br />
-          이미지에 관련된 설명을 확인할 수 있습니다.
-          <br />
-          이미지의 상세 설명입니다.
-          <br />
-          이미지에 관련된 설명을 확인할 수 있습니다.
-          <br />
-        </Content>
         <ButtonBox>
           {isEdit ? (
             <>
@@ -360,7 +313,7 @@ const GalleryDetailModal: React.FC<DetailModalProps> = ({
             </>
           )}
         </ButtonBox>
-      </ModalBox>
+      </DetailModalBox>
     </ModalBackground>
   );
 };

--- a/src/components/gallery/GalleryDetailModal.tsx
+++ b/src/components/gallery/GalleryDetailModal.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import styled from "styled-components";
+import closeIconUrl from "../../assets/icons/gallery_icon/image_close_icon.png";
+import { ModalBackground } from "./GalleryModal";
+import { CloseButton } from "./GalleryModal";
+import { ButtonBox, Button } from "./GalleryModal";
+
+interface DetailModalProps {
+  imageUrl: string;
+  onClose: () => void;
+}
+
+const ModalBox = styled.div`
+  width: 1000px;
+  height: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #fff;
+  border-radius: 20px;
+  padding: 10px;
+  z-index: 99;
+`;
+
+const DetailImage = styled.img`
+  width: 700px;
+  height: auto;
+  max-height: 100%;
+`;
+
+const Description = styled.p`
+  font: normal normal bold 20px/32px Noto Sans KR;
+  margin: 20px auto 20px 135px;
+  width: 700px;
+  white-wrap: nowrap;
+  border-box: box-sizing;
+  overflow-y: scroll;
+`;
+
+const GalleryDetailModal: React.FC<DetailModalProps> = ({
+  imageUrl,
+  onClose,
+}) => {
+  return (
+    <ModalBackground onClick={onClose}>
+      <ModalBox onClick={e => e.stopPropagation()}>
+        <CloseButton onClick={onClose}>
+          <img src={closeIconUrl} alt="close icon" />
+        </CloseButton>
+        <DetailImage src={imageUrl} alt="Image Detail" />
+        <Description>
+          이미지의 상세 설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세
+          설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세 설명입니다.
+          이미지의 상세한 설명입니다. 이미지의 상세 설명입니다. 이미지의 상세한
+          설명입니다. 이미지의 상세 설명입니다. 이미지의 상세한 설명입니다.
+          이미지의 상세 설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세
+          설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세 설명입니다.
+          이미지의 상세한 설명입니다. 이미지의 상세 설명입니다. 이미지의 상세한
+          설명입니다. 이미지의 상세 설명입니다. 이미지의 상세한 설명입니다.
+          이미지의 상세 설명입니다. 이미지의 상세한 설명입니다. 이미지의 상세
+          설명입니다. 이미지의 상세한 설명입니다.
+        </Description>
+        <ButtonBox>
+          <Button
+            color="#000"
+            borderColor="#000"
+            backgroundColor="#fff"
+            type="button">
+            Delete
+          </Button>
+          <Button color="#fff" backgroundColor="#000" type="button">
+            Save
+          </Button>
+        </ButtonBox>
+      </ModalBox>
+    </ModalBackground>
+  );
+};
+
+export default GalleryDetailModal;

--- a/src/components/gallery/GalleryModal.tsx
+++ b/src/components/gallery/GalleryModal.tsx
@@ -27,7 +27,7 @@ export const ModalBackground = styled.div`
   z-index: 98;
 `;
 
-const ModalBox = styled.div`
+export const ModalBox = styled.div`
   width: 740px;
   height: 520px;
   margin: 0 auto;
@@ -66,7 +66,7 @@ export const UploadBox = styled.div`
   cursor: pointer;
 `;
 
-const ImagePreview = styled.img`
+export const ImagePreview = styled.img`
   width: 600px;
   height: 320px;
   object-fit: cover;
@@ -74,13 +74,13 @@ const ImagePreview = styled.img`
   box-shadow: 0px 3px 6px #00000029;
 `;
 
-const ModalUploadIcon = styled.img`
+export const ModalUploadIcon = styled.img`
   width: 80px;
   height: 80px;
   text-align: center;
 `;
 
-const UploadDescription = styled.p`
+export const UploadDescription = styled.p`
   font: normal normal bold 20px/32px Noto Sans KR;
   margin-top: 20px;
   > img {
@@ -89,19 +89,20 @@ const UploadDescription = styled.p`
   }
 `;
 
-const FileNameBox = styled.div`
+export const FileNameBox = styled.div`
   display: flex;
+  align-items: center;
   margin: 20px auto 0px 65px;
   > svg {
     margin-right: 3px;
   }
 `;
 
-const Input = styled.input`
+export const Input = styled.input`
   display: none;
 `;
 
-const FileName = styled.p`
+export const FileName = styled.p`
   margin-left: 5px;
   text-align: center;
   font: normal normal bold 16px/18px Noto Sans KR;
@@ -128,7 +129,23 @@ export const Button = styled.button<stylesProps>`
     transition: transform 0.8s;
 `;
 
+export const Select = styled.select<stylesProps>`
+  margin-right: 8px;
+  color: ${props => (props.color ? "#000" : "#808080")};
+  padding: 2px 3px;
+  border: 1px solid #000;
+  font: normal normal bold 15px Noto Sans KR;
+  border-radius: 3px;
+  > option {
+    border: inherit;
+    font-size: 14px;
+  }
+`;
+
 const GalleryModal = ({ isModalChange }: ModalProps) => {
+  const [selectedCategory, setSelectedCategory] = useState<string | undefined>(
+    undefined,
+  );
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const modalBackgroundRef = useRef<HTMLDivElement>(null);
@@ -146,6 +163,11 @@ const GalleryModal = ({ isModalChange }: ModalProps) => {
     if (imageInputRef.current) {
       imageInputRef.current.click();
     }
+  };
+
+  // category
+  const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedCategory(e.target.value);
   };
 
   // selected image preview
@@ -209,11 +231,16 @@ const GalleryModal = ({ isModalChange }: ModalProps) => {
   const handleUpload = async () => {
     if (!selectedImage) {
       alert("파일을 선택해주세요.");
+    } else if (!selectedCategory) {
+      alert("카테고리를 선택해주세요.");
     }
 
     try {
-      if (selectedImage) {
-        const storageRef = ref(storage, `images/${selectedFileName}`);
+      if (selectedImage && selectedCategory) {
+        const storageRef = ref(
+          storage,
+          `images/${selectedCategory}/${selectedFileName}`,
+        );
         await uploadString(storageRef, selectedImage, "data_url");
         alert("업로드가 완료되었습니다.");
         window.location.href = "/gallery";
@@ -247,6 +274,17 @@ const GalleryModal = ({ isModalChange }: ModalProps) => {
         </UploadBox>
 
         <FileNameBox>
+          <Select
+            color={selectedCategory}
+            value={selectedCategory}
+            onChange={handleCategoryChange}>
+            <option value="" selected disabled hidden>
+              == 카테고리 선택 ==
+            </option>
+            <option value="office-photo">내부사진</option>
+            <option value="business">협력사</option>
+            <option value="jop-posting">채용공고</option>
+          </Select>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             height="1em"

--- a/src/components/gallery/GalleryModal.tsx
+++ b/src/components/gallery/GalleryModal.tsx
@@ -52,7 +52,7 @@ export const CloseButton = styled.button`
   }
 `;
 
-const UploadBox = styled.div`
+export const UploadBox = styled.div`
   width: 600px;
   height: 320px;
   display: flex;

--- a/src/components/gallery/GalleryModal.tsx
+++ b/src/components/gallery/GalleryModal.tsx
@@ -205,6 +205,7 @@ const GalleryModal = ({ isModalChange }: ModalProps) => {
     }
   };
 
+  // image upload
   const handleUpload = async () => {
     if (!selectedImage) {
       alert("파일을 선택해주세요.");

--- a/src/components/gallery/GalleryModal.tsx
+++ b/src/components/gallery/GalleryModal.tsx
@@ -11,10 +11,11 @@ interface ModalProps {
 
 interface stylesProps {
   color?: string;
+  borderColor?: string;
   backgroundColor?: string;
 }
 
-const ModalBackground = styled.div`
+export const ModalBackground = styled.div`
   position: fixed;
   display: flex;
   align-items: center;
@@ -39,7 +40,7 @@ const ModalBox = styled.div`
   z-index: 99;
 `;
 
-const CloseButton = styled.button`
+export const CloseButton = styled.button`
   margin: 20px;
   margin-left: auto;
   border: none;
@@ -106,24 +107,24 @@ const FileName = styled.p`
   font: normal normal bold 16px/18px Noto Sans KR;
 `;
 
-const ButtonBox = styled.div`
+export const ButtonBox = styled.div`
   margin: auto 20px 20px auto;
 `;
 
-const Button = styled.button<stylesProps>`
+export const Button = styled.button<stylesProps>`
   height: 45px;
   padding: 6px 16px;
   margin-left: 15px;
   text-align: center;
-  font: normal normal bold 25px/30px Noto Sans KR;
-  border: 1px solid #d2d2d2;
+  font: normal normal bold 20px/30px Noto Sans KR;
+  border: 2px solid ${props => props.borderColor || "#d2d2d2"};
   border-radius: 10px;
   cursor: pointer;
   color: ${props => props.color || "#000"};
   background-color: ${props => props.backgroundColor || "#fff"};
-  transition: transform 1s;
+  transition: transform 0.8s;
   &:hover {
-    transform: scale(1.15);
+    transform: scale(1.08);
     transition: transform 0.8s;
 `;
 
@@ -223,7 +224,7 @@ const GalleryModal = ({ isModalChange }: ModalProps) => {
 
   return (
     <ModalBackground onClick={handleClickBackground} ref={modalBackgroundRef}>
-      <ModalBox>
+      <ModalBox onClick={e => e.stopPropagation()}>
         <CloseButton type="button" onClick={isModalChange}>
           <img src={closeIconUrl} alt="close icon" />
         </CloseButton>
@@ -263,6 +264,7 @@ const GalleryModal = ({ isModalChange }: ModalProps) => {
         <ButtonBox>
           <Button
             color="#000"
+            borderColor="#000"
             backgroundColor="#fff"
             type="button"
             onClick={isModalChange}>
@@ -273,7 +275,7 @@ const GalleryModal = ({ isModalChange }: ModalProps) => {
             color="#fff"
             backgroundColor="#000"
             type="button">
-            OK
+            Upload
           </Button>
         </ButtonBox>
       </ModalBox>

--- a/src/components/gallery/GallerySection.tsx
+++ b/src/components/gallery/GallerySection.tsx
@@ -110,7 +110,7 @@ const GallerySection = ({ isModalChange }: ModalProps) => {
           <GalleryItem
             key={url}
             src={url}
-            alt={`${index} + image`}
+            alt={`${index} image`}
             onClick={() => openDetailModal(url)}
           />
         ))}

--- a/src/components/gallery/GallerySection.tsx
+++ b/src/components/gallery/GallerySection.tsx
@@ -3,6 +3,11 @@ import { useState, useEffect } from "react";
 import { getDownloadURL, listAll, ref } from "firebase/storage";
 import { storage } from "../../firebase";
 import uploadIconUrl from "../../assets/icons/gallery_icon/image_upload_icon.png";
+import GalleryDetailModal from "./GalleryDetailModal";
+
+interface ModalProps {
+  isModalChange: () => void;
+}
 
 const GalleryBox = styled.div`
   margin-top: 2rem;
@@ -48,14 +53,17 @@ const GalleryItem = styled.img`
   height: 260px;
   object-fit: cover;
   border-radius: 10px;
+  cursor: pointer;
+  transition: transform 0.8s;
+  &:hover {
+    transform: scale(1.02);
+    transition: transform 0.8s;
+  }
 `;
-
-interface ModalProps {
-  isModalChange: () => void;
-}
 
 const GallerySection = ({ isModalChange }: ModalProps) => {
   const [imgUrls, setImgUrls] = useState<string[]>([]);
+  const [selectedImageUrl, setSelectedImageUrl] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchImage = async () => {
@@ -81,6 +89,14 @@ const GallerySection = ({ isModalChange }: ModalProps) => {
     };
   }, []);
 
+  const openDetailModal = (imageUrl: string) => {
+    setSelectedImageUrl(imageUrl);
+  };
+
+  const closeDetailModal = () => {
+    setSelectedImageUrl(null);
+  };
+
   return (
     <GalleryBox>
       <GalleryHeader>
@@ -91,9 +107,21 @@ const GallerySection = ({ isModalChange }: ModalProps) => {
       </GalleryHeader>
       <GalleryContainer>
         {imgUrls.map((url, index) => (
-          <GalleryItem key={url} src={url} alt={`${index} + image`} />
+          <GalleryItem
+            key={url}
+            src={url}
+            alt={`${index} + image`}
+            onClick={() => openDetailModal(url)}
+          />
         ))}
       </GalleryContainer>
+
+      {selectedImageUrl && (
+        <GalleryDetailModal
+          imageUrl={selectedImageUrl}
+          onClose={closeDetailModal}
+        />
+      )}
     </GalleryBox>
   );
 };

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
+import { Gallerys } from "../components/SideBar/SideBar";
 import GallerySection from "../components/gallery/GallerySection";
 import GalleryModal from "../components/gallery/GalleryModal";
 
@@ -17,7 +18,7 @@ const Gallery = () => {
 
   return (
     <GalleryWrapper>
-      {/* 사이드바 컴포넌트 */}
+      <Gallerys />
 
       <GallerySection isModalChange={isModalChange} />
       {/* Modal */}


### PR DESCRIPTION
# Summary
갤러리 페이지 업데이트, 삭제 / 갤러리 폴더 별로 업로드, 읽기, 업데이트

# Describe your changes
- 갤러리 상세 모달 추가
  - 선택한 이미지가 잘리지 않고 모두 보이게 랜더링
  - 갤러리 업데이트 기능 추가 
    - 해당 이미지 삭제 후 선택한 이미지 업로드
    - 이미지 파일인지 확인, 이미지 미리보기 
  - 갤러리 삭제 기능 추가
    - 삭제 전 confirm, 해당 이미지 삭제
- storage에 갤러리 폴더 추가하여 기능 업데이트
  - 업로드 : 업로드 시 카테고리 select 추가하여 업로드할 폴더 선택
  -  읽기 : 모든 폴더의 이미지 읽어오기로 수정
  - 업데이트 : 업로드 시에 선택한 카테고리 폴더로 업데이트

# Issue number and link
close #2 
link : #2 